### PR TITLE
hotfix: fix auth since cookies not set in prod

### DIFF
--- a/application/frontend/src/api/httpClient.ts
+++ b/application/frontend/src/api/httpClient.ts
@@ -19,6 +19,8 @@ export const httpClient = (token?: string): AxiosInstance => {
 
     if (cookie) {
         headers['X-CSRF-TOKEN'] = cookie;
+    } else if (token) {
+        headers.Authorization = `Bearer ${token}`;
     }
 
     return axios.create({


### PR DESCRIPTION
Cookies is not properly set clientside when logging in in prod. Reverts to old auth temporarely