### PR TITLE
dev-env: env file for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Infrastructure Diagram](https://github.com//blankoslo/Pizza.v2/blob/main/README/infrastructure.png?raw=true)
 
 ## Slack App Bot setup
+
 1. Go to `https://api.slack.com/apps/`
 2. Click the `Create New App` button
 3. Choose `from scratch`
@@ -13,7 +14,7 @@
 8. Click `Event Subscriptions`
 9. Turn on `Enable Events`
 10. Open `Subscribe to bot events`
-11. Add the events `file_shared` `message.channels` `message.im`  `app_uninstalled` `tokens_revoked`
+11. Add the events `file_shared` `message.channels` `message.im` `app_uninstalled` `tokens_revoked`
 12. Click `OAuth & Permissions` in the menu
 13. Go down to `Scopes` and click `Add an OAuth Scope` and add the scopes found in `/application/backend/api/slack`'s GET `/install` method.
 14. Go to `App Home`
@@ -32,22 +33,27 @@
 ## How to run the system
 
 ### Development
+
 The frontend, backend, bot, message queue and database can all be run with docker compose by running `docker-compose up`. Optionally you can do `docker-compose up -d [service]` to only start one or more service. During development all services run behind an nginx instance to simplify their interactions. The ports are 80 and 443.
 
 As we use Ouath2 for authentication we are forced to use https. Nginx needs valid ssl certificates, so you are gonna need to generate one with the command `openssl req -x509 -nodes -newkey rsa:4096 -keyout nginx-selfsigned.key -out nginx-selfsigned.crt -sha256 -days 365` and add it to `application/containers/development`
 
-**NB:** You'll need to supply the docker-compose file with slack credentials as mention in the `Slack App Bot setup` section. You'll also need to supply cloudinary credentials if you want the uninstall handler to properly delete images, you should also update the `upload_preset` in `handle_file_share` in `bot/src/slack/__init__.py` to point to your own cloudinary account.
+**NB:** You'll need to supply the docker-compose file with slack credentials as mention in the `Slack App Bot setup` section. These are defined in a `.env` file in `application/containers/development` folder of the project. This file is not commited to the repository, so you have to create it manually. You can use the `.env.example` file as a template inside `application/containers/development`. You'll also need to supply cloudinary credentials if you want the uninstall handler to properly delete images, you should also update the `upload_preset` in `handle_file_share` in `bot/src/slack/__init__.py` to point to your own cloudinary account.
 
 ### Good to know
+
 Locales doesnt work properly in the alpine container used, meaning it's not a bug if stuff is localized wrong, such as the time string send in pizza event invites.
 
 ### Production
+
 #### Terraform Cloud
+
 This repository is connected to Terraform Cloud where it is automatically planned and then manually applied whenever a new tag is created.
 The branch used in Terraform Cloud is the `Build` branch, which gets created on every new version. This branch is the same as master, but it also contains the build files for the frontend application.
 A tag is automatically created through GitHub actions when a PR is merged into Main.
 
 #### Heroku
+
 We are using terraform to describe the infrastructure, which can be found in the `/infrastructure` folder. In addition to this the backend/bot have `Procfile`, `runtime.txt`, and `.locales` files that describe the process, heroku runtime and additional locales to include. While the frontend have `.static` in the `public` folder to indicate the application folder for the nginx buildpacker, and a `.gitignore` file to keep the files and folder in git.
 
 1. Go into the `infrastructure` folder and run `terraform apply` (not needed if using Terraform Cloud).
@@ -56,21 +62,27 @@ We are using terraform to describe the infrastructure, which can be found in the
 4. Create a CNAME record with the hostname specified in the main terraform file for both the frontend and the backend and point them to the `DNS TARGET`s from heroku. After a while routing and SSL should work flawlesly.
 
 Infrastructure:
-* Backend-app: contains the database, papertrail instance, Rabbitmq instance, and backend application  
-* Bot-app: contains an attachement to the database, an attachement to the papertrail instance, an attachement to the Rabbitmq instance, the bot worker
-* Frontend-app: contains a nginx instance with the build files from the `public` folder
+
+- Backend-app: contains the database, papertrail instance, Rabbitmq instance, and backend application
+- Bot-app: contains an attachement to the database, an attachement to the papertrail instance, an attachement to the Rabbitmq instance, the bot worker
+- Frontend-app: contains a nginx instance with the build files from the `public` folder
 
 ## Tests
+
 ### Backend
+
 The tests for this application were written using the pytest testing framework. The tests cover the blueprints, services, and broker handlers.
 
 To run the backend tests, navigate to the backend directory of the project and run the following command:
+
 ```
 python3 -m pytest tests
 ```
+
 Optionally you can add the options `-k [name of test suit or test function]` (to only run certain tests), `-s` (to show print statements) and `-v`/`-vv` (to make tests more verbose).
 
 ### Bot
+
 TODO
 
 ## Contributing Guidelines

--- a/application/containers/development/.env.example
+++ b/application/containers/development/.env.example
@@ -1,4 +1,5 @@
 # -------------------- For development -------------------
+# Create a file named ".env" in this directory and copy the contents of this file with your credentials into it.
 # Slack variables
 SLACK_APP_TOKEN=
 SLACK_CLIENT_ID=
@@ -10,6 +11,6 @@ CLOUDINARY_CLOUD_NAME=
 CLOUDINARY_API_KEY=
 CLOUDINARY_API_SECRET=
 
-# URI's
-FRONTEND_URI=   # https://localhost:4000, exposed port routed from nginx
-BACKEND_URI=    # http://backend:3000, docker-defined host w/ port from flask
+# URI's - Dont change unless host and ports are changed
+FRONTEND_URI=https://localhost:4000   # exposed port routed from nginx
+BACKEND_URI=http://backend:3000     # docker-defined host w/ port from flask

--- a/application/containers/development/.env.example
+++ b/application/containers/development/.env.example
@@ -1,0 +1,15 @@
+# -------------------- For development -------------------
+# Slack variables
+SLACK_APP_TOKEN=
+SLACK_CLIENT_ID=
+SLACK_CLIENT_SECRET=
+SLACK_SIGNING_SECRET=
+
+# Cloudinary for image uploads (optional for development)
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=
+
+# URI's
+FRONTEND_URI=   # https://localhost:4000, exposed port routed from nginx
+BACKEND_URI=    # http://backend:3000, docker-defined host w/ port from flask

--- a/application/containers/development/ENVIROMENT.md
+++ b/application/containers/development/ENVIROMENT.md
@@ -1,0 +1,9 @@
+# Enviroment variables
+
+# Development
+
+Envs for development are defined in the `.env` file in `application/containers/development` folder of the project. This file is not commited to the repository, so you have to create it manually. You can use the `.env.example` file as a template inside `application/containers/development`.
+
+# Production
+
+Envs for production are defined through terraform variables. You can find them documented in the `variables.tf` file inside the `infrastructure` and `infrastructure/system` folders. These are defined in the Terraform GUI in the browser when releasing a new version.

--- a/application/containers/development/ENVIROMENT.md
+++ b/application/containers/development/ENVIROMENT.md
@@ -1,9 +1,0 @@
-# Enviroment variables
-
-# Development
-
-Envs for development are defined in the `.env` file in `application/containers/development` folder of the project. This file is not commited to the repository, so you have to create it manually. You can use the `.env.example` file as a template inside `application/containers/development`.
-
-# Production
-
-Envs for production are defined through terraform variables. You can find them documented in the `variables.tf` file inside the `infrastructure` and `infrastructure/system` folders. These are defined in the Terraform GUI in the browser when releasing a new version.

--- a/application/containers/development/docker-compose.yml
+++ b/application/containers/development/docker-compose.yml
@@ -5,15 +5,15 @@ x-common-variables: &common-variables
   PYTHONPATH: /srv/bot
 
 x-common-slack-variables: &common-slack-variables
-  SLACK_APP_TOKEN: ""
-  SLACK_CLIENT_ID: ""
-  SLACK_CLIENT_SECRET: ""
-  SLACK_SIGNING_SECRET: ""
+  SLACK_APP_TOKEN: "${SLACK_APP_TOKEN}"
+  SLACK_CLIENT_ID: "${SLACK_CLIENT_ID}"
+  SLACK_CLIENT_SECRET: "${SLACK_CLIENT_SECRET}"
+  SLACK_SIGNING_SECRET: "${SLACK_SIGNING_SECRET}"
 
 x-common-cloudinary-variables: &common-cloudinary-variables
-  CLOUDINARY_CLOUD_NAME: ""
-  CLOUDINARY_API_KEY: ""
-  CLOUDINARY_API_SECRET: ""
+  CLOUDINARY_CLOUD_NAME: "${CLOUDINARY_CLOUD_NAME}"
+  CLOUDINARY_API_KEY: "${CLOUDINARY_API_KEY}"
+  CLOUDINARY_API_SECRET: "${CLOUDINARY_API_SECRET}"
 
 x-common-rabbitmq-variables: &common-rabbitmq-variables
   MQ_URL: amqp://guest:guest@rabbitmq:5672/%2F
@@ -49,6 +49,8 @@ services:
     environment:
       - CHOKIDAR_USEPOLLING=true
       - WDS_SOCKET_PORT=0
+      - WATCHPACK_POLLING=true
+      - NEXT_PUBLIC_BACKEND_URI="${BACKEND_URI}"
     depends_on:
       - backend
     networks:
@@ -79,7 +81,7 @@ services:
       FLASK_APP: "main.py"
       FLASK_RUN_HOST: "0.0.0.0"
       FLASK_RUN_PORT: "3000"
-      FRONTEND_URI: "https://localhost:4434"
+      FRONTEND_URI: "${FRONTEND_URI}"
       <<:
         [
           *common-slack-variables,


### PR DESCRIPTION
## Whats changed
Docker-compose.yml now uses .env-file for setting variables for development. Template .env.example is provided in application/containers/development. README also updated explaining changes for setting up local dev environment

## Motivation
Separate configuration of docker-compose file and setting of environment/bot credentials. This reduces risk of accidentally commiting bot credentials to github 