### PR TITLE
hotfix; bot invitations

### DIFF
--- a/application/bot/src/i18n.py
+++ b/application/bot/src/i18n.py
@@ -20,7 +20,7 @@ class Translator:
         self.data = {}
         self.locale = default_locale
         self.logger: logging.Logger = injector.get(logging.Logger)
-        self.timezone = lang_timezone_map[self.locale]
+        self.timezone = pytz.timezone(lang_timezone_map[self.locale])
 
         for filename in glob.glob(os.path.join(language_folder, '*.json')):
             loc = os.path.splitext(os.path.basename(filename))[0]


### PR DESCRIPTION
Boten krasjer hver gang den sender ut invitasjoner, siden self.timezone, som man bruker til å parse alle meldinger med, er av typen string og ikke pytz.timezone. Siden det skjer i boten tror backenden alt er good og den vil ikke prøve å sende noe på nytt. Derav vil flyten i invitasjons prosessen fortsatte som vanlig, aka grunnen til at folk har fått purringer på invitasjoner de ikke har fått. 