### PR TITLE
PB-39ae: Bugfix create event onboarding

### DIFF
--- a/application/next-frontend/src/api/useRestaurants.ts
+++ b/application/next-frontend/src/api/useRestaurants.ts
@@ -31,7 +31,7 @@ const useRestaurants = () => {
                 {
                     populateCache: true,
                     rollbackOnError: true,
-                    revalidate: false,
+                    revalidate: true,
                 },
             )
         } catch (e) {


### PR DESCRIPTION
quickfix for å kunne lage events i steg 2 på onboarding siden, hvis vi har

`populateCache: true`
`revalidate: false`

får vi ikke id som blir oppretta i db fra backend, som betyr at vi ikke kan lage et event med en restaurant man akkurat lagde i steg 1. 

I fremtiden burde sikkert swr options skilles ut, slik at man kan bruke passende options utifra settingen.
