### PR TITLE
PB-39af: minor fix to display active users in adminpanel

### DIFF
--- a/application/next-frontend/src/Admin/scenarios/SlackUsers.tsx
+++ b/application/next-frontend/src/Admin/scenarios/SlackUsers.tsx
@@ -1,9 +1,8 @@
 import { CardComponent } from 'Admin/components/CardComponent'
 import { useSlackUsers } from '@/api/useSlackUsers'
-import { Switch } from '@mui/material'
 
 const SlackUsers = () => {
-    const { data, isLoading, error, updateUser } = useSlackUsers()
+    const { data, isLoading, error } = useSlackUsers()
 
     return (
         <CardComponent title="People">
@@ -13,17 +12,13 @@ const SlackUsers = () => {
                 ? `Failed to load users due to the following error: ${error?.info.msg}`
                 : !data || data.length == 0
                 ? 'No users found.'
-                : data.map((slackUser) => (
-                      <div key={slackUser.slack_id} className="flex items-center justify-between py-2">
-                          <Switch
-                              checked={slackUser.active}
-                              onChange={() => updateUser(slackUser)}
-                              color="success"
-                              inputProps={{ 'aria-label': 'controlled' }}
-                          />
-                          <p className="ml-3">{slackUser.current_username}</p>
-                      </div>
-                  ))}
+                : data
+                      .filter((slackUser) => slackUser.active) // filter users based of the active property
+                      .map((slackUser) => (
+                          <div key={slackUser.slack_id} className="flex items-center justify-between py-2">
+                              <p>{slackUser.current_username}</p>
+                          </div>
+                      ))}
         </CardComponent>
     )
 }


### PR DESCRIPTION
Fjerner switchen fra users på adminpanelet og hvis kun aktive brukere. Skal egt bare displaye kanalen, men endepuntket for det finnes ikke enda i backend. Tenkte det var bedre å bare mekke midlertidig sånn her så blir det ikke misforståelse mtp switching. 