### PR TITLE
feat: endpoint for current channel-name and ws users

### DIFF
--- a/application/backend/app/api/crud/slack_users.py
+++ b/application/backend/app/api/crud/slack_users.py
@@ -1,9 +1,11 @@
-from flask import views
+import requests
+from flask import jsonify, views
 from flask_smorest import Blueprint, abort
 from app.models.slack_user_schema import SlackUserResponseSchema, SlackUserUpdateSchema, SlackUserQueryArgsSchema
 from flask_jwt_extended import jwt_required, current_user
 from app.services.injector import injector
 from app.services.slack_user_service import SlackUserService
+from app.services.slack_organization_service import SlackOrganizationService
 
 bp = Blueprint("users", "users", url_prefix="/users", description="Operations on users")
 
@@ -19,6 +21,41 @@ class SlackUsers(views.MethodView):
         total, slack_users = slack_user_service.get(filters=args, page=pagination_parameters.page, per_page=pagination_parameters.page_size, order_by_ascending=True, team_id=current_user.slack_organization_id)
         pagination_parameters.item_count = total
         return slack_users
+    
+@bp.route("/current-channel")
+class SlackChannel(views.MethodView):
+    @jwt_required()
+    def get(self):
+        """Get current channel info"""
+        slack_organization = injector.get(SlackOrganizationService)
+        org = slack_organization.get_by_id(team_id=current_user.slack_organization_id)
+        channel_id = org.channel_id
+
+        if channel_id is None:
+            return jsonify({"channel_name": None, "users": [] })
+
+        request_url = f'https://slack.com/api/conversations.info?channel={channel_id}'
+        res = requests.post(request_url, headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {org.access_token}"
+        }).json()
+        
+        if not res["ok"]:
+            abort(500, message = "Error getting channel info")
+
+        channel_name = res["channel"]["name"]
+
+        slack_user_service = injector.get(SlackUserService)
+        count, slack_users = slack_user_service.get(filters={"slack_organization_id": current_user.slack_organization_id})
+        returned_users = [
+            {
+                "id": user.slack_id,
+                "current_username": user.current_username,
+                "active": user.active,
+            } for user in slack_users
+        ]
+    
+        return jsonify({"channel_name": channel_name, "users": returned_users })
 
 @bp.route("/<slack_user_id>")
 class SlackUsersById(views.MethodView):


### PR DESCRIPTION
Played around to see if this was easily doable, considering we only store the channel-id in the database (not the channel name)

This works, with a hardcoded url-request to the slack-api.  

### Endpoint returnes
```json
{
    "channel_name": "Current pizzabot channel name",
    "users": ["List of users in the workspace"]
}
```

Could be changed to filter in only active users