### PR TITLE
Pb-39z: adds invitation status frontend

### DIFF
--- a/application/next-frontend/src/Admin/scenarios/Events/components/NextEventInfo.tsx
+++ b/application/next-frontend/src/Admin/scenarios/Events/components/NextEventInfo.tsx
@@ -1,0 +1,27 @@
+const NextEventInfo = ({
+    event_id,
+    resturantName,
+    date,
+    time,
+    meridiem,
+}: {
+    event_id: string
+    resturantName: string
+    date: string
+    time: string
+    meridiem: string
+}) => {
+    console.log(event_id)
+    return (
+        <div className="mt-5 flex flex-col">
+            <div className="italic text-green-primary">Next event:</div>
+            <h3 className="text-2xl font-semibold leading-10">{resturantName}</h3>
+            <h4 className="text-xl font-semibold leading-10">{date}</h4>
+            <span className="text-xl font-semibold leading-7">
+                {time} <span className="italic">{meridiem}</span>
+            </span>
+        </div>
+    )
+}
+
+export { NextEventInfo }

--- a/application/next-frontend/src/Admin/scenarios/Events/components/NextEventInfo.tsx
+++ b/application/next-frontend/src/Admin/scenarios/Events/components/NextEventInfo.tsx
@@ -52,7 +52,7 @@ const NextEventInfo = ({
                 ) : error ? (
                     `Failed to load invitation status. ${error?.info.msg}`
                 ) : !data || !data.length ? (
-                    'Invitations has not been sent yet.'
+                    'Invitations have not been sent yet.'
                 ) : (
                     <InvitationsStatus invitations={data} />
                 )}

--- a/application/next-frontend/src/Admin/scenarios/Events/components/NextEventInfo.tsx
+++ b/application/next-frontend/src/Admin/scenarios/Events/components/NextEventInfo.tsx
@@ -12,10 +12,10 @@ const InvitationsStatus = ({ invitations }: { invitations: ApiInvitation[] }) =>
     )
 
     return (
-        <div className="flex flex-col font-workSans">
-            <span className="">{responses.accepted} Accepted </span>
-            <span className="">{responses.waiting} Waiting </span>
-            <span className="">{responses.declined} Declined </span>
+        <div className="flex flex-col gap-1 font-workSans">
+            <span className="tabular-nums">{responses.accepted} Accepted </span>
+            <span className="tabular-nums">{responses.waiting} Waiting </span>
+            <span className="tabular-nums">{responses.declined} Declined </span>
         </div>
     )
 }

--- a/application/next-frontend/src/Admin/scenarios/Events/components/NextEventInfo.tsx
+++ b/application/next-frontend/src/Admin/scenarios/Events/components/NextEventInfo.tsx
@@ -1,3 +1,25 @@
+import { ApiInvitation, useInvitations } from '@/api/useInvitations'
+
+const InvitationsStatus = ({ invitations }: { invitations: ApiInvitation[] }) => {
+    const responses = invitations.reduce(
+        (prev, next) => {
+            if (next.rsvp === 'unanswered') prev.waiting++
+            else if (next.rsvp === 'attending') prev.accepted++
+            else if (next.rsvp === 'not attending') prev.declined++
+            return prev
+        },
+        { waiting: 0, accepted: 0, declined: 0 },
+    )
+
+    return (
+        <div className="flex flex-col font-workSans">
+            <span className="">{responses.accepted} Accepted </span>
+            <span className="">{responses.waiting} Waiting </span>
+            <span className="">{responses.declined} Declined </span>
+        </div>
+    )
+}
+
 const NextEventInfo = ({
     event_id,
     resturantName,
@@ -11,7 +33,8 @@ const NextEventInfo = ({
     time: string
     meridiem: string
 }) => {
-    console.log(event_id)
+    const { data, error, isLoading } = useInvitations(event_id)
+
     return (
         <div className="mt-5 flex flex-col">
             <div className="italic text-green-primary">Next event:</div>
@@ -20,6 +43,20 @@ const NextEventInfo = ({
             <span className="text-xl font-semibold leading-7">
                 {time} <span className="italic">{meridiem}</span>
             </span>
+
+            <div className="mt-8">
+                <h4 className="italic text-green-primary">Invitation status: </h4>
+
+                {isLoading ? (
+                    'Loading...'
+                ) : error ? (
+                    `Failed to load invitation status. ${error?.info.msg}`
+                ) : !data || !data.length ? (
+                    'Invitations has not been sent yet.'
+                ) : (
+                    <InvitationsStatus invitations={data} />
+                )}
+            </div>
         </div>
     )
 }

--- a/application/next-frontend/src/Admin/scenarios/Events/index.tsx
+++ b/application/next-frontend/src/Admin/scenarios/Events/index.tsx
@@ -40,9 +40,7 @@ const Events = () => {
                     meridiem={meridiem}
                 />
             )}
-            <div className="mb-10 mt-[11.7rem] italic text-green-primary">
-                {upcomingEventsMessage(futureEvents.length)}
-            </div>
+            <div className="mb-8 mt-16 italic text-green-primary">{upcomingEventsMessage(futureEvents.length)}</div>
         </CardComponent>
     )
 }

--- a/application/next-frontend/src/Admin/scenarios/Events/index.tsx
+++ b/application/next-frontend/src/Admin/scenarios/Events/index.tsx
@@ -3,6 +3,7 @@ import { CardComponent } from 'Admin/components/CardComponent'
 import { useEvents } from '@/api/useEvents'
 import { ApiEvent } from '@/api/useEvents'
 import { format } from 'date-fns'
+import { NextEventInfo } from './components/NextEventInfo'
 
 const futureDate = (date: ApiEvent) => new Date(date.time) >= new Date()
 
@@ -20,7 +21,7 @@ const upcomingEventsMessage = (eventsNumber: number) =>
 const Events = () => {
     const { data, isLoading, error } = useEvents()
     const futureEvents = data?.filter(futureDate).sort(differenceBetweenTwoDates) ?? []
-    const [time, meridiem] = futureEvents.length > 0 ? eventTimeFormatted(futureEvents[0].time) : [0, 0]
+    const [time, meridiem] = futureEvents.length > 0 ? eventTimeFormatted(futureEvents[0].time) : ['0', '0']
 
     return (
         <CardComponent title="Events" modalContent={<CreatePizzaEventCard selectedDate={new Date()} />}>
@@ -31,14 +32,13 @@ const Events = () => {
             ) : !data || !data.length || !futureEvents.length ? (
                 ''
             ) : (
-                <div className="mt-5 flex flex-col">
-                    <div className="italic text-green-primary">Next event:</div>
-                    <h3 className="text-2xl font-semibold leading-10">{futureEvents[0].restaurant?.name}</h3>
-                    <h4 className="text-xl font-semibold leading-10">{eventDateFormatted(futureEvents[0].time)}</h4>
-                    <span className="text-xl font-semibold leading-7">
-                        {time} <span className="italic">{meridiem}</span>
-                    </span>
-                </div>
+                <NextEventInfo
+                    event_id={futureEvents[0].id}
+                    resturantName={futureEvents[0].restaurant?.name ?? 'Cannot find resturant name'}
+                    date={eventDateFormatted(futureEvents[0].time)}
+                    time={time}
+                    meridiem={meridiem}
+                />
             )}
             <div className="mb-10 mt-[11.7rem] italic text-green-primary">
                 {upcomingEventsMessage(futureEvents.length)}

--- a/application/next-frontend/src/api/useInvitations.ts
+++ b/application/next-frontend/src/api/useInvitations.ts
@@ -1,0 +1,20 @@
+import { useAuthedSWR } from './useAuthedSWR'
+import { SlackUser } from './useSlackUsers'
+
+export type ApiInvitation = {
+    event_id: string
+    invited_at: string
+    reminded_at: string
+    rsvp: 'unanswered' | 'attending' | 'not attending'
+    slack_id: string
+    slack_user: SlackUser
+}
+
+const useInvitations = (eventId: string) => {
+    const endpoint = `/invitations/${eventId}`
+    const { data, isLoading, error } = useAuthedSWR<ApiInvitation[]>(endpoint)
+
+    return { data, isLoading, error }
+}
+
+export { useInvitations }


### PR DESCRIPTION
I think this is a good start for how to implement this. Feel free to come with further suggestions.
I added a header above the invitations to make it more clear, but idk what the designers think and could change it

from: 
![image](https://github.com/blankoslo/Pizza.v3/assets/69514522/4b526833-eee1-498a-b808-3463a79176a8)
to: 
![image](https://github.com/blankoslo/Pizza.v3/assets/69514522/f68f2c66-3308-4b92-ba95-5a61b4def37b)
