### PR TITLE
Quick fix to calendar colours

### DIFF
--- a/application/next-frontend/src/Admin/scenarios/Events/components/EventCalendar.tsx
+++ b/application/next-frontend/src/Admin/scenarios/Events/components/EventCalendar.tsx
@@ -126,7 +126,7 @@ const EventCalendar = () => {
 
                                 // Styling
                                 const image = pizzaImages[Math.floor(Math.random() * pizzaImages.length)]
-                                const styling = `h-[3.75rem] w-[4.15rem] border text-dark
+                                const styling = `h-[3.75rem] w-[4.15rem] border border-green-primary text-dark
                                     ${
                                         today >= currentTomorrow
                                             ? 'opacity-50'
@@ -159,7 +159,7 @@ const EventCalendar = () => {
                                 )
                             }
                         }
-                        return <td className="h-[3.75rem] w-[4.15rem] border" key={dayOfWeek} />
+                        return <td className="h-[3.75rem] w-[4.15rem] border border-green-primary" key={dayOfWeek} />
                     })}
             </tr>
         )
@@ -174,7 +174,7 @@ const EventCalendar = () => {
     }
 
     return (
-        <div className="inline-block bg-green-light px-6 pb-6 pt-3 text-green-primary">
+        <div className="inline-block bg-green-calendar px-6 pb-6 pt-3 text-green-primary">
             <div className="flex justify-center">
                 <Image
                     onClick={() => setPreviousMonth()}

--- a/application/next-frontend/tailwind.config.ts
+++ b/application/next-frontend/tailwind.config.ts
@@ -32,6 +32,7 @@ const config: Config = {
                     tertiary: '#003F1E',
                     quaternary: '#004B24',
                     light: '#CFF6E2',
+                    calendar: '#EDFFF6',
                 },
                 yellow: '#FFF8C1',
                 shade: '#6A5412',


### PR DESCRIPTION
The calendar borders and background had changed colours. There are a lot of different shades of green in Figma right now, and I think I mixed them up on my last PR, which lead to changing the ones we are already using.

When I checked, it was all dark green and the borders were grey. Now it looks like this (again):

<img width="915" alt="Screenshot 2023-11-22 at 14 06 23" src="https://github.com/blankoslo/Pizza.v3/assets/46766403/f29a3794-e72c-42f4-9985-ba923ab39bc0">
