### PR TITLE
Improving the process of syncing users to channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 8. Click `Event Subscriptions`
 9. Turn on `Enable Events`
 10. Open `Subscribe to bot events`
-11. Add the events `file_shared` `message.channels` `message.im` `app_uninstalled` `tokens_revoked` `member_left_channel`
+11. Add the events `file_shared` `message.channels` `message.im` `app_uninstalled` `tokens_revoked` `member_left_channel` `member_joined_channel`
 12. Click `OAuth & Permissions` in the menu
-13. Go down to `Scopes` and click `Add an OAuth Scope` and add the scopes found in `/application/backend/api/slack`'s GET `/install` method.
+13. Go down to `Scopes` and click `Add an OAuth Scope` and add the scopes found in `/application/backend/app/api/slack`'s GET `/install` method.
 14. Go to `App Home`
 15. Go down to `Show Tabs` and switch on `Messages Tab` (to allow DMs)
 16. Go to `OAuth & Permissions` under `Redirect URLs`

--- a/application/backend/app/models/slack_user.py
+++ b/application/backend/app/models/slack_user.py
@@ -10,7 +10,7 @@ class SlackUser(db.Model):
     slack_id = sa.Column(sa.String, primary_key=True)
     current_username = sa.Column(sa.String, nullable=False)
     first_seen = sa.Column(sa.DateTime(timezone=True), nullable=False, server_default=func.now())
-    active = sa.Column(sa.Boolean, nullable=False, server_default='t')
+    active = sa.Column(sa.Boolean, nullable=False, server_default='f')
     priority = sa.Column(sa.Integer, nullable=False, server_default='1')
     email = sa.Column(sa.String, nullable=True)
     ratings = relationship("Rating", backref="slack_user", cascade="all, delete-orphan")

--- a/application/backend/app/services/broker/handlers/update.py
+++ b/application/backend/app/services/broker/handlers/update.py
@@ -42,7 +42,7 @@ def update_invitation(request: dict):
 @MessageHandler.handle('update_slack_user', UpdateSlackUserRequestSchema, UpdateSlackUserResponseSchema)
 def update_slack_user(request: dict):
     logger = injector.get(logging.Logger)
-    slack_user_service = injector.get(SlackUserService)
+    slack_user_service:SlackUserService = injector.get(SlackUserService)
     users_to_update = request['users_to_update']
 
     success = True

--- a/application/bot/src/api/bot_api.py
+++ b/application/bot/src/api/bot_api.py
@@ -97,7 +97,8 @@ class BotApi:
 
         return channel_id
     
-    def handle_user_joined_channel(self, team_id, user_id, channel_id):
+    def handle_user_joined_channel(self, team_id, user_id, channel_id, slack_client):
+        translator = injector.get(Translator)
         slack_installation = self.client.get_slack_installation(team_id=team_id)
         if slack_installation is None or 'channel_id' not in slack_installation:
             self.logger.error("Failed to get slack installation for team %s", team_id)
@@ -115,6 +116,8 @@ class BotApi:
         }
 
         self.client.update_slack_users(slack_users=[user_to_update])
+
+        self.send_slack_message(channel_id=user_id, text=translator.translate("userJoinedPizzaChannel"), slack_client=slack_client)
 
     
     def handle_user_left_channel(self, team_id, user_id, channel_id, slack_client):

--- a/application/bot/src/api/bot_api.py
+++ b/application/bot/src/api/bot_api.py
@@ -43,7 +43,6 @@ class BotApi:
         
 
     def join_channel(self, slack_client, team_id, channel_id):
-
         # Log and exit if we were unable to find a channel
         if channel_id is None:
             self.logger.error("Bot cannot join None channel")
@@ -376,6 +375,11 @@ class BotApi:
 
     def get_invited_users(self):
         return self.client.get_invited_unanswered_user_ids()
+    
+    def sync_users_from_organizations(self):
+        slack_organizations = self.client.get_slack_organizations()
+        for slack_organization in slack_organizations:
+            self.sync_users_from_organization(team_id=slack_organization['team_id'], bot_token=slack_organization['bot_token'])
 
     def sync_users_from_organization(self, team_id, bot_token):
         installation_info = self.client.get_slack_installation(team_id=team_id)

--- a/application/bot/src/api/bot_api.py
+++ b/application/bot/src/api/bot_api.py
@@ -107,7 +107,6 @@ class BotApi:
         
         self.logger.info(f"User {user_id} joined channel in organization {team_id}")
 
-        # set active active
         user_to_update = {
             'id': user_id,
             'team_id': team_id,
@@ -128,6 +127,7 @@ class BotApi:
             return
         
         scheduled_events = self.client.get_scheduled_events_for_user(team_id=team_id, user_id=user_id)
+        
         if scheduled_events == False:
             self.logger.error("Failed to get scheduled events for user %s", user_id)
             return
@@ -168,7 +168,7 @@ class BotApi:
                 
         # Send message to user that they no longer will be invited to events
         self.send_slack_message(
-            channel_id=scheduled_event['slack_message_channel'],
+            channel_id=user_id,
             text=self.translator.translate("userLeftPizzaChannel"),
             slack_client=slack_client
         )

--- a/application/bot/src/api/slack_api.py
+++ b/application/bot/src/api/slack_api.py
@@ -14,8 +14,7 @@ class SlackApi:
             raise ValueError("Either 'client' or 'token' must be provided.")
         self.logger: logging.Logger = injector.get(logging.Logger)
 
-    # Returns a list of users in the workspace, 
-    # with their active status updated.
+
     def get_users_to_update_by_channel(self, channel_id):
         # list of user ids in channel
         members = self.get_channel_users(channel_id=channel_id)

--- a/application/bot/src/api/slack_api.py
+++ b/application/bot/src/api/slack_api.py
@@ -12,7 +12,7 @@ class SlackApi:
             self.client = WebClient(token=token)
         else:
             raise ValueError("Either 'client' or 'token' must be provided.")
-        self.logger = injector.get(logging.Logger)
+        self.logger: logging.Logger = injector.get(logging.Logger)
 
     # Returns a list of users in the workspace, 
     # with their active status updated.
@@ -24,11 +24,14 @@ class SlackApi:
         full_users = self.get_slack_users()
         users_to_update = self.get_real_users(full_users)
 
-        for user in users_to_update:
-            user["active"] = user["id"] in members
-            user["email"] = user["profile"]["email"]
 
-        return users_to_update
+        for user_id in members:
+            user = users_to_update.get(user_id)
+            if user:
+                user["active"] = True
+                user["email"] = user["profile"]["email"]
+
+        return list(users_to_update.values())
 
 
     def get_channel_users(self, channel_id: str) -> list[str]:
@@ -72,7 +75,7 @@ class SlackApi:
     def get_real_users(self, all_users):
         # 'is_restricted': is multichannel guest.
         # 'is_ultra_restricted': is singlechannel guest.
-        return [u for u in all_users if not u['deleted'] and not u['is_bot'] and not u['name'] == "slackbot"] # type : list
+        return {u["id"]: u for u in all_users if not u['deleted'] and not u['is_bot'] and not u['name'] == "slackbot"} # type : dict
 
     def send_slack_message(self, channel_id, text=None, blocks=None, thread_ts=None):
         return self.client.chat_postMessage(

--- a/application/bot/src/lang/en.json
+++ b/application/bot/src/lang/en.json
@@ -2,7 +2,7 @@
   "thanksForFile": "Thanks for the file! 🤙",
   "pizzaChannelError": "Something went wrong. Couldn't set Pizza channel.",
   "pizzaChannelErrorScheduledEvents": "There are $count scheduled events in the previous pizza channel. Please cancel them in the admin panel before switching channel.",
-  "pizzaChannelConfirm": "Pizza channel has now been set to <#$channel_id>",
+  "pizzaChannelConfirm": "Pizza channel has now been set to <#$channel_id> 🍕 Members of this channel will now receive invitations to future events.",
   "botWelcome": "Hello! I'm the pizza bot. If you want to change the channel I use, you can go to the appropriate channel and use the command '/set-pizza-channel'. If the channel is private, you need to add me first.",
   "eventReminder": "Hey there! I didn't hear any more from you. Are you coming?",
   "eventFinalized": "Hello there! $user_ids! You're going to have 🍕 at $restaurant_name, $time_stamp. $booker is booking the table!",
@@ -31,5 +31,6 @@
   "invitedButLeftChannelUnanswered": "Since you left the PizzaBot channel, I assume you do not want to attend 😕",
   "invitedButLeftChannelWithdrawn": "Since you left the PizzaBot channel, I assume you do not want to attend 😕 You have been withdrawn from the event",
   "userLeftPizzaChannel": "You left the PizzaBot channel 😕 You will no longer receive invitations to future events.",
+  "userJoinedPizzaChannel": "You joined the PizzaBot channel 🍕 You will receive invitations to future events.",
   "adminPanelURLCommand": "The admin panel can be found <$adminPanelURL | here>"
 }

--- a/application/bot/src/lang/no.json
+++ b/application/bot/src/lang/no.json
@@ -31,5 +31,6 @@
   "invitedButLeftChannelUnanswered": "Siden du forlot PizzaBot kanalen, antar jeg du ikke vil være med 😕",
   "invitedButLeftChannelWithdrawn": "Siden du forlot PizzaBot kanalen, antar jeg du ikke vil være med 😕 Du har blitt avmeldt arrangementet.",
   "userLeftPizzaChannel": "Du har forlatt PizzaBot kanalen 😕 Du vil ikke lenger motta invitasjoner til fremtidige arrangementer.",
+  "userJoinedPizzaChannel": "Du har blitt med i PizzaBot kanalen 🍕 Du vil motta invitasjoner til fremtidige arrangementer.",
   "adminPanelURLCommand": "Adminpanelet kan du finne <$adminPanelURL | her>"
 }

--- a/application/bot/src/scheduler/__init__.py
+++ b/application/bot/src/scheduler/__init__.py
@@ -34,9 +34,4 @@ def clean_up_invitations():
     with injector.get(BotApi) as ba:
         ba.clean_up_invitations()
 
-@scheduler.scheduled_job('interval', id='sync_users_from_organizations', hours=6, jitter=120)
-def sync_users_from_organizations():
-    logger = injector.get(logging.Logger)
-    logger.info("Syncing db with slack on scheduled task")
-    with injector.get(BotApi) as ba:
-        ba.sync_users_from_organizations()
+

--- a/application/bot/src/scheduler/__init__.py
+++ b/application/bot/src/scheduler/__init__.py
@@ -38,7 +38,7 @@ def clean_up_invitations():
 @scheduler.scheduled_job('date')
 def sync_users_from_organizations():
     logger = injector.get(logging.Logger)
-    logger.info("Syncing db with slack on startup")
+    logger.info("Syncing users in db with slack on startup")
     with injector.get(BotApi) as ba:
         ba.sync_users_from_organizations()
 

--- a/application/bot/src/scheduler/__init__.py
+++ b/application/bot/src/scheduler/__init__.py
@@ -35,3 +35,10 @@ def clean_up_invitations():
         ba.clean_up_invitations()
 
 
+@scheduler.scheduled_job('date')
+def sync_users_from_organizations():
+    logger = injector.get(logging.Logger)
+    logger.info("Syncing db with slack on startup")
+    with injector.get(BotApi) as ba:
+        ba.sync_users_from_organizations()
+

--- a/application/bot/src/slack/__init__.py
+++ b/application/bot/src/slack/__init__.py
@@ -89,6 +89,7 @@ def handle_event(body, say, context):
 @slack_app.event("member_joined_channel")
 def handle_event(body, say, context):
     event = body["event"]
+    client = SlackApi(client=context["client"])
     # Handle a user joining the channel
     if "channel" in event and "user" in event and "team" in event:
         channel_id = event["channel"]
@@ -96,7 +97,7 @@ def handle_event(body, say, context):
         user_id = event["user"]
         ba: BotApi
         with injector.get(BotApi) as ba:
-            ba.handle_user_joined_channel(channel_id=channel_id, team_id=team_id, user_id=user_id)
+            ba.handle_user_joined_channel(channel_id=channel_id, team_id=team_id, user_id=user_id, slack_client=client)
 
 
 def handle_rsvp(body, ack, attending, client):

--- a/application/bot/src/slack/__init__.py
+++ b/application/bot/src/slack/__init__.py
@@ -82,8 +82,21 @@ def handle_event(body, say, context):
         channel_id = event["channel"]
         team_id = event["team"]
         user_id = event["user"]
+        ba: BotApi
         with injector.get(BotApi) as ba:
             ba.handle_user_left_channel(channel_id=channel_id, team_id=team_id, user_id=user_id, slack_client=client)
+
+@slack_app.event("member_joined_channel")
+def handle_event(body, say, context):
+    event = body["event"]
+    # Handle a user joining the channel
+    if "channel" in event and "user" in event and "team" in event:
+        channel_id = event["channel"]
+        team_id = event["team"]
+        user_id = event["user"]
+        ba: BotApi
+        with injector.get(BotApi) as ba:
+            ba.handle_user_joined_channel(channel_id=channel_id, team_id=team_id, user_id=user_id)
 
 
 def handle_rsvp(body, ack, attending, client):
@@ -186,6 +199,7 @@ def handle_file_share(event, say, token, client):
 def handle_some_command(ack, body, say, context):
     translator = injector.get(Translator)
     ack()
+    ba: BotApi
     with injector.get(BotApi) as ba:
         team_id = body["team_id"]
         message_channel_id = body["channel_id"]


### PR DESCRIPTION
Endrer litt på logikken for hvordan boten og backenden syncer brukere mtp om de er active eller ikke. 

Før ble det kjørt en sync hver 6 time, hvor boten loopa gjennom aller brukere i alle workspace for å finne ut hvem som var aktive eller ikke. Det tok også opp til 6 timer før en bruker joina kanalen pizzaboten jobba i, til de faktisk ble registrert. 

Endrer først og fremst på at boten nå lytter på events hvor brukere joiner kanaler også endre active property til brukeren fortløpende. 

Regla med at boten looper gjennom alle brukerne skjer nå kun når boten joiner ny kanal og en gang når boten starter opp(i tilfelle boten er tidvis nede), og da bare for den aktuelle kanalen, og denne prosessen har jeg også endra litt på for å gjøre den litt mer effektiv. 

~~PS: har ikke testa noe som helst enda~~ ser ut som det funker fjell.
